### PR TITLE
add multi-line (>396 chars) support for long boosts into IRC messages

### DIFF
--- a/src/irc/__init__.py
+++ b/src/irc/__init__.py
@@ -111,11 +111,14 @@ def cli(
                         logging.debug("Donation too low, skipping", data)
                         continue
 
-                    message = _new_message(data, value)
-                    logging.debug(message)
+                    fullmessage = _new_message(data, value)
+                    logging.debug(fullmessage)
 
-                    for channel in irc_channel:
-                        bot.send("PRIVMSG", target=channel, message=message)
+                    message = chunks(fullmessage, 396)
+
+                    for chunk in message:
+                        for channel in irc_channel:
+                            bot.send("PRIVMSG", target=channel, message=chunk)
 
                 except Exception as exception:
                     click.echo(exception)
@@ -183,3 +186,8 @@ def _new_message(data, value, numerology_func=number_to_numerology):
         data += " " + app
 
     return data
+
+
+def chunks(l, n):
+    n = max(1, n)
+    return (l[i : i + n] for i in range(0, len(l), n))


### PR DESCRIPTION
Pretty simple, `chunks()` separates a long string into a list of strings, each element having a length no longer than 396. Then iterate through that list and send each chunk as an IRC message.